### PR TITLE
fix devicetree for Orin NX/Nano

### DIFF
--- a/patch/dt_camera_OrinNano_35.3.1+/0001-Modified-tegra234-p3768-0000-a0.dts-to-integrate-VC-.patch
+++ b/patch/dt_camera_OrinNano_35.3.1+/0001-Modified-tegra234-p3768-0000-a0.dts-to-integrate-VC-.patch
@@ -1,6 +1,6 @@
-From f94b0c7faa324e3b424ac3947b9e57fffb4d59d3 Mon Sep 17 00:00:00 2001
-From: "/setup.sh" <support@vision-components.com>
-Date: Thu, 18 May 2023 11:16:29 +0200
+From c07ce2abf34f02f5380c14b486a9362ffc4e6fff Mon Sep 17 00:00:00 2001
+From: Felix Ruess <felix.ruess@roboception.de>
+Date: Wed, 7 Jun 2023 16:28:41 +0200
 Subject: [PATCH] Modified tegra234-p3768-0000-a0.dts to integrate VC MIPI
  Driver and deactivate IMX219 and IMX477 driver.
 
@@ -9,7 +9,7 @@ Subject: [PATCH] Modified tegra234-p3768-0000-a0.dts to integrate VC MIPI
  1 file changed, 11 insertions(+), 2 deletions(-)
 
 diff --git a/hardware/nvidia/platform/t23x/p3768/kernel-dts/cvb/tegra234-p3768-0000-a0.dtsi b/hardware/nvidia/platform/t23x/p3768/kernel-dts/cvb/tegra234-p3768-0000-a0.dtsi
-index 01f41c8..6ec1542 100644
+index 01f41c8..aae4bf8 100644
 --- a/hardware/nvidia/platform/t23x/p3768/kernel-dts/cvb/tegra234-p3768-0000-a0.dtsi
 +++ b/hardware/nvidia/platform/t23x/p3768/kernel-dts/cvb/tegra234-p3768-0000-a0.dtsi
 @@ -10,14 +10,21 @@
@@ -30,20 +30,20 @@ index 01f41c8..6ec1542 100644
 +#ifdef VC_MIPI
 +	#include "tegra234-camera-vc-mipi-cam.dtsi"
 +#else
-+        #include "tegra234-p3768-camera-rbpcv3-imx477.dtsi"
-+        #include "tegra234-p3768-camera-rbpcv2-imx219.dtsi"
++	#include "tegra234-p3768-camera-rbpcv3-imx477.dtsi"
++	#include "tegra234-p3768-camera-rbpcv2-imx219.dtsi"
 +#endif
  
  / {
  	gpio-keys {
-@@ -285,6 +292,7 @@
- 		};
+@@ -261,6 +268,7 @@
+ 		status = "okay";
  	};
  
 +#ifndef VC_MIPI
- 	cam_i2cmux{
- 		i2c@0 {
- 			rbpcv2_imx219_a@10 {
+ 	tegra-capture-vi  {
+ 		ports {
+ 			port@0 {
 @@ -336,4 +344,5 @@
  			};
  		};

--- a/src/devicetree/NV_DevKit_OrinNano/tegra234-camera-vc-mipi-cam.dtsi
+++ b/src/devicetree/NV_DevKit_OrinNano/tegra234-camera-vc-mipi-cam.dtsi
@@ -82,7 +82,7 @@
 			vc_vi_port0: port@0 {
 				reg = <0>;
 				vc_vi_in0: endpoint {
-					port-index = <1>;
+					port-index = <0>;
 					bus-width = <BUS_WIDTH>;
 					remote-endpoint = <&vc_csi_out0>;
 				};
@@ -115,7 +115,7 @@
 						vc_csi_chan0_port0: port@0 {
 						reg = <0>;
 						vc_csi_in0: endpoint@0 {
-							port-index = <1>;
+							port-index = <0>;
 							bus-width = <BUS_WIDTH>;
 							remote-endpoint = <&vc_mipi_out0>;
 						};
@@ -186,10 +186,10 @@
 				// You don't have to change any settings if just want to use the V4L API.
 				mode0 {
 					num_lanes                = NUM_LANES;
-					tegra_sinterface         = "serial_b";
+					tegra_sinterface         = "serial_a";
 					embedded_metadata_height = VC_MIPI_METADATA_H;
 					readout_orientation      = "0";
-					lane_polarity            = "6";
+					lane_polarity            = "0";
 
 					// ----------------------------------------------------
 					// If you want to use GStreamer with nvarguscamerasrc
@@ -242,7 +242,7 @@
 					port@0 {
 						reg = <0>;
 						vc_mipi_out0: endpoint {
-							port-index = <1>;
+							port-index = <0>;
 							bus-width = <BUS_WIDTH>;
 							remote-endpoint = <&vc_csi_in0>;
 						};


### PR DESCRIPTION
Fix device tree for cam0 on Orin NX/Nano on Auvidea JNX42.

Tested on Orin NX with two IMX296.