### PR TITLE
16 support for external trigger ov9281

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -4,6 +4,8 @@
 * New Features
     * Added support for VC MIPI Camera Modules 
       * IMX565
+    * Bugfix
+      * Added trigger support for OV9281
     * Added support for board support packages
       * NVIDIA L4T 32.7.3
       * NVIDIA L4T 35.2.1 *(only NVIDIA Jetson Xavier NX and AGX Xavier)*

--- a/src/driver/vc_mipi_camera.c
+++ b/src/driver/vc_mipi_camera.c
@@ -6,7 +6,7 @@
 #include "vc_mipi_core.h"
 #include "vc_mipi_modules.h"
 
-#define VERSION "0.15.0"
+#define VERSION "0.14.0"
 // #define VC_CTRL_VALUE
 
 
@@ -447,7 +447,7 @@ static struct camera_common_pdata *vc_parse_dt(struct tegracam_device *tc_dev)
 }
 
 static struct camera_common_sensor_ops vc_sensor_ops = {
-            .frmfmt_table = NULL,
+        .frmfmt_table = NULL,
         .read_reg = vc_read_reg,
         .write_reg = vc_write_reg,
         .set_mode = vc_set_mode,

--- a/src/driver/vc_mipi_core.h
+++ b/src/driver/vc_mipi_core.h
@@ -16,7 +16,7 @@
 #define FLAG_RESET_ALWAYS               (1 <<  0)
 #define FLAG_EXPOSURE_SONY              (1 <<  1)
 #define FLAG_EXPOSURE_NORMAL            (1 <<  2)
-#define FLAG_SET_FLASH_DURATION         (1 <<  3)
+#define FLAG_EXPOSURE_OMNIVISION        (1 <<  3)
 
 #define FLAG_IO_ENABLED                 (1 <<  4)
 #define FLAG_FORMAT_GBRG                (1 <<  5)

--- a/src/driver/vc_mipi_modules.c
+++ b/src/driver/vc_mipi_modules.c
@@ -675,16 +675,12 @@ static void vc_init_ctrl_ov7251(struct vc_ctrl *ctrl, struct vc_desc* desc)
         ctrl->flash_factor              = 1758241 >> 4; // (1000 << 4)/9100 >> 4
         ctrl->flash_toffset             = 4;
 
-        ctrl->flags                     = FLAG_EXPOSURE_NORMAL;
-        ctrl->flags                    |= FLAG_IO_ENABLED | FLAG_SET_FLASH_DURATION;
+        ctrl->flags                     = FLAG_EXPOSURE_OMNIVISION;
+        ctrl->flags                    |= FLAG_IO_ENABLED;
 }
 
 // ------------------------------------------------------------------------------------------------
 //  Settings for OV9281 (Rev.02)
-//
-//  TODO: 
-//  - Trigger mode could not be activated. 
-//  - Additionally: When 0x0108 = 0x01 => exposure time has no effect.
 
 static void vc_init_ctrl_ov9281(struct vc_ctrl *ctrl, struct vc_desc* desc)
 {
@@ -716,8 +712,8 @@ static void vc_init_ctrl_ov9281(struct vc_ctrl *ctrl, struct vc_desc* desc)
         ctrl->flash_factor              = 1758241 >> 4; // (1000 << 4)/9100 >> 4
         ctrl->flash_toffset             = 4;
 
-        ctrl->flags                     = FLAG_EXPOSURE_NORMAL;
-        ctrl->flags                    |= FLAG_IO_ENABLED | FLAG_SET_FLASH_DURATION;
+        ctrl->flags                     = FLAG_EXPOSURE_OMNIVISION;
+        ctrl->flags                    |= FLAG_IO_ENABLED;
         ctrl->flags                    |= FLAG_TRIGGER_EXTERNAL;
 }
 


### PR DESCRIPTION
- OV9281 is now able to be triggered from external input
- flash out signal aligns with the exposure duration
- exposure resolution is about 9 µs