### PR TITLE
add support vor L4T 35.5.0

### DIFF
--- a/bin/config/L4T/R35.5.0.sh
+++ b/bin/config/L4T/R35.5.0.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+DEV_URL=https://developer.nvidia.com/downloads/embedded/l4t/r35_release_v5.0
+
+case $VC_MIPI_SOM in
+        AGXXavier|XavierNX|XavierNXSD|AGXOrin|OrinNX8GB|OrinNX16GB|OrinNano4GB_SD|OrinNano8GB_SD|OrinNano4GB_NVME|OrinNano8GB_NVME)
+                BSP_FILE=jetson_linux_r35.5.0_aarch64.tbz2
+                ;;
+esac
+
+RFS_FILE=tegra_linux_sample-root-filesystem_r35.5.0_aarch64.tbz2
+SRC_FILE=public_sources.tbz2
+
+CHECK4MD5=1
+
+BSP_FILE_CHECKSUM="aed884077fff66a8f2d7c825ec4a3c57"
+RFS_FILE_CHECKSUM=""
+SRC_FILE_CHECKSUM="83c4e20bb82aa81b938fd9b0c85ad03f"
+
+. $BIN_DIR/config/L4T/urls_35.1.0+.sh

--- a/bin/config/L4T/urls_35.1.0+.sh
+++ b/bin/config/L4T/urls_35.1.0+.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 case $VC_MIPI_BSP in
-35.1.0|35.2.1|35.3.1)
+35.1.0|35.2.1|35.3.1|35.5.0)
         case $VC_MIPI_SOM in
         AGXXavier|XavierNX|XavierNXSD|AGXOrin|OrinNX8GB|OrinNX16GB|OrinNano4GB_SD|OrinNano8GB_SD|OrinNano4GB_NVME|OrinNano8GB_NVME)
                 BSP_URL=$DEV_URL/release

--- a/bin/config/configure.sh
+++ b/bin/config/configure.sh
@@ -26,7 +26,7 @@ KERNEL_OUT=$KERNEL_SOURCE/build
 MODULES_OUT=$KERNEL_SOURCE/modules
 DRIVER_DST_DIR=$KERNEL_SOURCE/kernel/nvidia/drivers/media/i2c
 case $VC_MIPI_BSP in
-35.1.0|35.2.1|35.3.1)
+35.1.0|35.2.1|35.3.1|35.5.0)
         KERNEL_DIR=kernel/kernel-5.10/
         MODULES_BSP=$BSP_DIR/Linux_for_Tegra/rootfs/usr
         DTB_OUT=$KERNEL_OUT/arch/arm64/boot/dts/nvidia
@@ -65,8 +65,8 @@ else
         exit 1
 fi
 
-DTSI_FILE_DICT=( 
-         ["Auvidea_J20_AGXXavier"]="tegra194-camera-vc-mipi-cam.dtsi" 
+DTSI_FILE_DICT=(
+         ["Auvidea_J20_AGXXavier"]="tegra194-camera-vc-mipi-cam.dtsi"
                ["Auvidea_J20_TX2"]="tegra186-camera-vc-mipi-cam.dtsi"
             ["Auvidea_JNX30_Nano"]="tegra210-camera-vc-mipi-cam.dtsi"
             ["Auvidea_JNX42_Nano"]="tegra210-camera-vc-mipi-cam.dtsi"
@@ -74,14 +74,14 @@ DTSI_FILE_DICT=(
         ["Auvidea_JNX42_XavierNX"]="tegra194-camera-vc-mipi-cam.dtsi"
           ["Auvidea_JNX42_OrinNX"]="tegra234-camera-vc-mipi-cam.dtsi"
         ["Auvidea_JNX42_OrinNano"]="tegra234-camera-vc-mipi-cam.dtsi"
-                ["NV_DevKit_Nano"]="tegra210-camera-vc-mipi-cam.dtsi" 
+                ["NV_DevKit_Nano"]="tegra210-camera-vc-mipi-cam.dtsi"
             ["NV_DevKit_OrinNano"]="tegra234-camera-vc-mipi-cam.dtsi"
             ["NV_DevKit_XavierNX"]="tegra194-camera-vc-mipi-cam.dtsi"
           ["Auvidea_JNX30D_TX2NX"]="tegra186-camera-vc-mipi-cam.dtsi"
 )
 
-DTSI_DEST_DICT=( 
-         ["Auvidea_J20_AGXXavier"]="$KERNEL_SOURCE/hardware/nvidia/platform/t19x/common/kernel-dts/t19x-common-modules" 
+DTSI_DEST_DICT=(
+         ["Auvidea_J20_AGXXavier"]="$KERNEL_SOURCE/hardware/nvidia/platform/t19x/common/kernel-dts/t19x-common-modules"
                ["Auvidea_J20_TX2"]="$KERNEL_SOURCE/hardware/nvidia/platform/t18x/common/kernel-dts/t18x-common-modules"
             ["Auvidea_JNX30_Nano"]="$KERNEL_SOURCE/hardware/nvidia/platform/t210/porg/kernel-dts/porg-platforms"
             ["Auvidea_JNX42_Nano"]="$KERNEL_SOURCE/hardware/nvidia/platform/t210/porg/kernel-dts/porg-platforms"
@@ -89,7 +89,7 @@ DTSI_DEST_DICT=(
         ["Auvidea_JNX42_XavierNX"]="$KERNEL_SOURCE/hardware/nvidia/platform/t19x/jakku/kernel-dts/common"
           ["Auvidea_JNX42_OrinNX"]="$KERNEL_SOURCE/hardware/nvidia/platform/t23x/p3768/kernel-dts/cvb"
         ["Auvidea_JNX42_OrinNano"]="$KERNEL_SOURCE/hardware/nvidia/platform/t23x/p3768/kernel-dts/cvb"
-                ["NV_DevKit_Nano"]="$KERNEL_SOURCE/hardware/nvidia/platform/t210/porg/kernel-dts/porg-platforms" 
+                ["NV_DevKit_Nano"]="$KERNEL_SOURCE/hardware/nvidia/platform/t210/porg/kernel-dts/porg-platforms"
             ["NV_DevKit_OrinNano"]="$KERNEL_SOURCE/hardware/nvidia/platform/t23x/p3768/kernel-dts/cvb"
             ["NV_DevKit_XavierNX"]="$KERNEL_SOURCE/hardware/nvidia/platform/t19x/jakku/kernel-dts/common"
           ["Auvidea_JNX30D_TX2NX"]="$KERNEL_SOURCE/hardware/nvidia/platform/t18x/lanai/kernel-dts/common"
@@ -168,8 +168,11 @@ AGXXavier|XavierNX|XavierNXSD|TX2|TX2i|TX2NX|OrinNano4GB_SD|OrinNano8GB_SD|OrinN
         35.3.1)
                 PATCHES+=('kernel_Xavier_35.3.1+')
                 ;;
+        35.5.0)
+                PATCHES+=('kernel_Xavier_35.5.0+')
+                ;;
         esac
-        
+
 esac
 
 case $VC_MIPI_SOM in

--- a/bin/config/setup.sh
+++ b/bin/config/setup.sh
@@ -53,10 +53,10 @@ soms=(
 "NVIDIA Jetson TX2 NX (production) (https://developer.nvidia.com/embedded/jetson-tx2-nx)"
 "NVIDIA Jetson Orin NX 8GB (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nx)"
 "NVIDIA Jetson Orin NX 16GB (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nx)"
-"NVIDIA Jetson Orin Nano 4GB SD (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"        
-"NVIDIA Jetson Orin Nano 8GB SD (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"        
-"NVIDIA Jetson Orin Nano 4GB NVME (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"        
-"NVIDIA Jetson Orin Nano 8GB NVME (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"        
+"NVIDIA Jetson Orin Nano 4GB SD (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"
+"NVIDIA Jetson Orin Nano 8GB SD (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"
+"NVIDIA Jetson Orin Nano 4GB NVME (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"
+"NVIDIA Jetson Orin Nano 8GB NVME (devkit) (https://developer.nvidia.com/embedded/jetson-modules#jetson_orin_nano)"
 )
 
 som_keys=(
@@ -145,6 +145,7 @@ bsps=(
 "NVIDIA L4T 35.1.0 (https://developer.nvidia.com/embedded/jetson-linux-r351)"
 "NVIDIA L4T 35.2.1 (https://developer.nvidia.com/embedded/jetson-linux-r3521)"
 "NVIDIA L4T 35.3.1 (https://developer.nvidia.com/embedded/jetson-linux-r3531)"
+"NVIDIA L4T 35.5.0 (https://developer.nvidia.com/embedded/jetson-linux-r3550)"
 )
 
 bsps_keys=(
@@ -160,6 +161,7 @@ bsps_keys=(
 "35.1.0"
 "35.2.1"
 "35.3.1"
+"35.5.0"
 )
 
 choose_bsp() {
@@ -220,7 +222,7 @@ setup_driver() {
                 choose_board 1 4 5
                 choose_bsp 1 2 3 4 5 6 7 8
                 ;;
-        XavierNX|XavierNXSD) 
+        XavierNX|XavierNXSD)
                 choose_board 2 4 5
                 choose_bsp 1 2 3 4 5 6 7 9 10 11
                 ;;
@@ -238,11 +240,11 @@ setup_driver() {
                 ;;
         OrinNano4GB_SD|OrinNano8GB_SD|OrinNano4GB_NVME|OrinNano8GB_NVME)
                 choose_board 3 5
-                choose_bsp 11
+                choose_bsp 11 12
                 ;;
         OrinNX8GB|OrinNX16GB)
                 choose_board 5
-                choose_bsp 10 11
+                choose_bsp 10 11 12
         esac
         check_configuration $1 $2
         write_configuration

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -138,7 +138,7 @@ setup_nvidia_driver() {
                 echo "Could not find NVIDIA display driver sha1 file! (pwd $(pwd))"
                 exit 1
         fi
- 
+
         SHA_SUM_FILE_VAR="$(cat $SHA_SUM_FILE | awk '{print $1}')"
         if [ -z $SHA_SUM_FILE_VAR ]
         then
@@ -253,7 +253,7 @@ create_target_user() {
         echo "Create target user ..."
         cd $BSP_DIR/Linux_for_Tegra
         case $VC_MIPI_BSP in
-        32.6.1|32.7.1|32.7.2|32.7.3|32.7.4|35.1.0|35.2.1|35.3.1)
+        32.6.1|32.7.1|32.7.2|32.7.3|32.7.4|35.1.0|35.2.1|35.3.1|35.5.0)
 
                 sudo ./tools/l4t_create_default_user.sh --username ${TARGET_USER} --password ${TARGET_PW} \
                         --hostname nvidia --autologin --accept-license
@@ -323,11 +323,11 @@ setup_target() {
         date_time=$(date '+%Y%m%d_%H%M%S')
         known_hosts_filepath_backup=${known_hosts_filepath}_backup_by_vc_setup_${date_time}
         if [[ -e ${known_hosts_filepath} ]]
-        then 
+        then
                 # Backup User's known_hosts file => known_host__backup_by_vc_setup_YYYYMMDD_HHMMSS.
                 echo "Backup known_hosts file..."
                 cp -v ${known_hosts_filepath} ${known_hosts_filepath_backup}
-                
+
                 # Remove already existing connection credential with this given IP.
                 ssh-keygen -f ${known_hosts_filepath} -R ${TARGET_IP}
         fi
@@ -392,7 +392,7 @@ while [ $# != 0 ] ; do
                 setup_toolchain
                 setup_user_credentials
                 setup_bsp
-# If the user likes to pre-install the test directory with test scripts 
+# If the user likes to pre-install the test directory with test scripts
 # in the configured user-home directory of the target system,
 # the following function can be activated.
 #                setup_target_files

--- a/patch/kernel_Xavier_35.5.0+/0001-Added-RAW8-grey-RAW10-y10-and-RAW12-y12-format-to-th.patch
+++ b/patch/kernel_Xavier_35.5.0+/0001-Added-RAW8-grey-RAW10-y10-and-RAW12-y12-format-to-th.patch
@@ -1,0 +1,103 @@
+From 56442c694b99f3e33158f5c4f4385ed3f8fa1e66 Mon Sep 17 00:00:00 2001
+From: Peter Martienssen <peter.martienssen@liquify-consulting.de>
+Date: Tue, 28 Sep 2021 14:59:26 +0200
+Subject: [PATCH 1/4] Added RAW8 (grey), RAW10 (y10) and RAW12 (y12) format to
+ the tegra framework.
+
+---
+ .../media/platform/tegra/camera/camera_common.c   | 15 +++++++++++++++
+ .../media/platform/tegra/camera/sensor_common.c   |  8 ++++++++
+ .../media/platform/tegra/camera/vi/vi5_formats.h  | 14 ++++++++++----
+ 3 files changed, 33 insertions(+), 4 deletions(-)
+
+diff --git a/kernel/nvidia/drivers/media/platform/tegra/camera/camera_common.c b/kernel/nvidia/drivers/media/platform/tegra/camera/camera_common.c
+index 7feee1634..3f52edb17 100644
+--- a/kernel/nvidia/drivers/media/platform/tegra/camera/camera_common.c
++++ b/kernel/nvidia/drivers/media/platform/tegra/camera/camera_common.c
+@@ -121,6 +121,21 @@ static const struct camera_common_colorfmt camera_common_color_fmts[] = {
+ 		V4L2_COLORSPACE_SRGB,
+ 		V4L2_PIX_FMT_VYUY,
+ 	},
++	{
++		MEDIA_BUS_FMT_Y8_1X8,
++		V4L2_COLORSPACE_RAW,
++		V4L2_PIX_FMT_GREY,
++	},
++	{
++		MEDIA_BUS_FMT_Y10_1X10,
++		V4L2_COLORSPACE_RAW,
++		V4L2_PIX_FMT_Y10,
++	},
++	{
++		MEDIA_BUS_FMT_Y12_1X12,
++		V4L2_COLORSPACE_RAW,
++		V4L2_PIX_FMT_Y12,
++	},
+ 	/*
+ 	 * The below two formats are not supported by VI4,
+ 	 * keep them at the last to ensure they get discarded
+diff --git a/kernel/nvidia/drivers/media/platform/tegra/camera/sensor_common.c b/kernel/nvidia/drivers/media/platform/tegra/camera/sensor_common.c
+index 32f7c417a..f5a5bfa6b 100644
+--- a/kernel/nvidia/drivers/media/platform/tegra/camera/sensor_common.c
++++ b/kernel/nvidia/drivers/media/platform/tegra/camera/sensor_common.c
+@@ -227,6 +227,14 @@ static int extract_pixel_format(
+ 		*format = V4L2_PIX_FMT_UYVY;
+ 	else if (strncmp(pixel_t, "yuv_vyuy16", size) == 0)
+ 		*format = V4L2_PIX_FMT_VYUY;
++	else if (strncmp(pixel_t, "gray", size) == 0)
++		*format = V4L2_PIX_FMT_GREY;
++	else if (strncmp(pixel_t, "y10", size) == 0)
++		*format = V4L2_PIX_FMT_Y10;
++	else if (strncmp(pixel_t, "y12", size) == 0)
++		*format = V4L2_PIX_FMT_Y12;
++	else if (strncmp(pixel_t, "bayer_rggb8", size) == 0)
++		*format = V4L2_PIX_FMT_SRGGB8;
+ 	else {
+ 		pr_err("%s: Need to extend format%s\n", __func__, pixel_t);
+ 		return -EINVAL;
+diff --git a/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_formats.h b/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+index 51cbbad5b..cfa85dff6 100644
+--- a/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_formats.h
++++ b/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_formats.h
+@@ -96,6 +96,8 @@
+ 				RAW8, SGBRG8, "GBGB.. RGRG.."),
+ 	TEGRA_VIDEO_FORMAT(RAW8, 8, SBGGR8_1X8, 1, 1, T_R8,
+ 				RAW8, SBGGR8, "BGBG.. GRGR.."),
++	TEGRA_VIDEO_FORMAT(RAW8, 8, Y8_1X8, 1, 1, T_R8,
++				RAW8, GREY, "GRAY8"),
+
+     /* RAW 14 */
+ 	TEGRA_VIDEO_FORMAT(RAW14, 14, SRGGB14_1X14, 2, 1, T_R16,
+@@ -108,14 +110,16 @@
+ 				RAW14, SBGGR14, "BGBG.. GRGR.."),
+
+ 	/* RAW 10 */
+-	TEGRA_VIDEO_FORMAT(RAW10, 10, SRGGB10_1X10, 2, 1, T_R16,
++	TEGRA_VIDEO_FORMAT(RAW10, 10, SRGGB10_1X10, 2, 1, T_R16_I,
+ 				RAW10, SRGGB10, "RGRG.. GBGB.."),
+-	TEGRA_VIDEO_FORMAT(RAW10, 10, SGRBG10_1X10, 2, 1, T_R16,
++	TEGRA_VIDEO_FORMAT(RAW10, 10, SGRBG10_1X10, 2, 1, T_R16_I,
+ 				RAW10, SGRBG10, "GRGR.. BGBG.."),
+-	TEGRA_VIDEO_FORMAT(RAW10, 10, SGBRG10_1X10, 2, 1, T_R16,
++	TEGRA_VIDEO_FORMAT(RAW10, 10, SGBRG10_1X10, 2, 1, T_R16_I,
+ 				RAW10, SGBRG10, "GBGB.. RGRG.."),
+-	TEGRA_VIDEO_FORMAT(RAW10, 10, SBGGR10_1X10, 2, 1, T_R16,
++	TEGRA_VIDEO_FORMAT(RAW10, 10, SBGGR10_1X10, 2, 1, T_R16_I,
+ 				RAW10, SBGGR10, "BGBG.. GRGR.."),
++	TEGRA_VIDEO_FORMAT(RAW10, 10, Y10_1X10, 2, 1, T_R16_I,
++				RAW10, Y10, "GRAY10"),
+
+ 	/* RAW 12 */
+ 	TEGRA_VIDEO_FORMAT(RAW12, 12, SRGGB12_1X12, 2, 1, T_R16,
+@@ -126,6 +130,8 @@
+ 				RAW12, SGBRG12, "GBGB.. RGRG.."),
+ 	TEGRA_VIDEO_FORMAT(RAW12, 12, SBGGR12_1X12, 2, 1, T_R16,
+ 				RAW12, SBGGR12, "BGBG.. GRGR.."),
++	TEGRA_VIDEO_FORMAT(RAW12, 12, Y12_1X12, 2, 1, T_R16_I,
++				RAW12, Y12, "GRAY12"),
+
+ 	/* RGB888 */
+ 	TEGRA_VIDEO_FORMAT(RGB888, 24, RGB888_1X24, 4, 1, T_A8R8G8B8,
+--
+2.25.1
+

--- a/patch/kernel_Xavier_35.5.0+/0001-Added-VC-MIPI-Driver-sources-to-Makefile.patch
+++ b/patch/kernel_Xavier_35.5.0+/0001-Added-VC-MIPI-Driver-sources-to-Makefile.patch
@@ -1,0 +1,50 @@
+From 536cc7abd0c1a771862afc466e7ef717f6413f82 Mon Sep 17 00:00:00 2001
+From: "/setup.sh" <support@vision-components.com>
+Date: Tue, 6 Sep 2022 14:25:38 +0200
+Subject: [PATCH] Added VC MIPI Driver sources to Makefile.
+
+---
+ kernel/kernel-5.10/arch/arm64/configs/defconfig               | 1 +
+ kernel/kernel-5.10/arch/arm64/configs/tegra_android_defconfig | 1 +
+ kernel/nvidia/drivers/media/i2c/Makefile                      | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/kernel/kernel-5.10/arch/arm64/configs/defconfig b/kernel/kernel-5.10/arch/arm64/configs/defconfig
+index c49c5c304..850e547b3 100644
+--- a/kernel/kernel-5.10/arch/arm64/configs/defconfig
++++ b/kernel/kernel-5.10/arch/arm64/configs/defconfig
+@@ -885,6 +885,7 @@ CONFIG_NV_VIDEO_IMX318=m
+ CONFIG_NV_VIDEO_LC898212=m
+ CONFIG_NV_VIDEO_OV5693=m
+ CONFIG_NV_VIDEO_OV9281=m
++CONFIG_NV_VIDEO_VC_MIPI=y
+ CONFIG_NV_VIDEO_OV10823=m
+ CONFIG_NV_VIDEO_OV23850=m
+ CONFIG_I2C_IOEXPANDER_PCA9570=m
+diff --git a/kernel/kernel-5.10/arch/arm64/configs/tegra_android_defconfig b/kernel/kernel-5.10/arch/arm64/configs/tegra_android_defconfig
+index c1016393e..501a4a899 100644
+--- a/kernel/kernel-5.10/arch/arm64/configs/tegra_android_defconfig
++++ b/kernel/kernel-5.10/arch/arm64/configs/tegra_android_defconfig
+@@ -892,6 +892,7 @@ CONFIG_NV_VIDEO_IMX318=m
+ CONFIG_NV_VIDEO_LC898212=m
+ CONFIG_NV_VIDEO_OV5693=m
+ CONFIG_NV_VIDEO_OV9281=m
++CONFIG_NV_VIDEO_VC_MIPI=y
+ CONFIG_NV_VIDEO_OV10823=m
+ CONFIG_NV_VIDEO_OV23850=m
+ CONFIG_I2C_IOEXPANDER_PCA9570=m
+diff --git a/kernel/nvidia/drivers/media/i2c/Makefile b/kernel/nvidia/drivers/media/i2c/Makefile
+index af6122bca..97541f880 100644
+--- a/kernel/nvidia/drivers/media/i2c/Makefile
++++ b/kernel/nvidia/drivers/media/i2c/Makefile
+@@ -13,6 +13,7 @@ obj-$(CONFIG_NV_VIDEO_IMX318) += nv_imx318.o
+ obj-$(CONFIG_NV_VIDEO_LC898212) += nv_lc898212.o
+ obj-$(CONFIG_NV_VIDEO_OV5693) += nv_ov5693.o
+ obj-$(CONFIG_NV_VIDEO_OV9281) += nv_ov9281.o
++obj-$(CONFIG_NV_VIDEO_VC_MIPI) += vc_mipi_camera.o vc_mipi_core.o vc_mipi_modules.o
+ obj-$(CONFIG_NV_VIDEO_OV10823) += nv_ov10823.o
+ obj-$(CONFIG_NV_VIDEO_OV23850) += nv_ov23850.o
+ obj-$(CONFIG_I2C_IOEXPANDER_PCA9570) += pca9570.o
+-- 
+2.25.1
+

--- a/patch/kernel_Xavier_35.5.0+/0001-Added-VC-MIPI-driver-to-Kconfig.patch
+++ b/patch/kernel_Xavier_35.5.0+/0001-Added-VC-MIPI-driver-to-Kconfig.patch
@@ -1,0 +1,33 @@
+From aa0b998085be767ed233752af4d266c28a68fdfa Mon Sep 17 00:00:00 2001
+From: "/setup.sh" <support@vision-components.com>
+Date: Tue, 27 Sep 2022 19:52:43 +0200
+Subject: [PATCH] Added VC MIPI driver to Kconfig
+
+---
+ kernel/nvidia/drivers/media/i2c/Kconfig | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/kernel/nvidia/drivers/media/i2c/Kconfig b/kernel/nvidia/drivers/media/i2c/Kconfig
+index 8362bc8..da3ff99 100644
+--- a/kernel/nvidia/drivers/media/i2c/Kconfig
++++ b/kernel/nvidia/drivers/media/i2c/Kconfig
+@@ -90,6 +90,16 @@ config NV_VIDEO_OV9281
+ 	  To compile this driver as a module, choose M here: the module
+ 	  will be called ov9281.
+ 
++config NV_VIDEO_VC_MIPI
++	tristate "Vision Components MIPI CSI-2 camera sensor support"
++	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
++	help
++	  This is a Video4Linux2 sensor driver for the Vision Components
++	  MIPI CSI-2 camera sensor, for use with the tegra isp.
++
++	  To compile this driver as a module, choose M here: the module
++	  will be called vc_mipi.
++
+ config NV_VIDEO_OV10823
+ 	tristate "OmniVision OV10823 camera sensor support"
+ 	depends on I2C && VIDEO_V4L2 && VIDEO_V4L2_SUBDEV_API
+-- 
+2.25.1
+

--- a/patch/kernel_Xavier_35.5.0+/0001-Added-controls-trigger_mode-io_mode-black_level-and-.patch
+++ b/patch/kernel_Xavier_35.5.0+/0001-Added-controls-trigger_mode-io_mode-black_level-and-.patch
@@ -1,0 +1,195 @@
+From 994d33af29fb82295379d0a6c122f7e894a1095b Mon Sep 17 00:00:00 2001
+From: Felix Ruess <felix.ruess@roboception.de>
+Date: Tue, 5 Sep 2023 15:43:38 +0200
+Subject: [PATCH] Added controls trigger_mode, io_mode, black_level and
+ single_trigger to the tegra framework
+
+---
+ .../platform/tegra/camera/tegracam_ctrls.c    | 118 ++++++++++++++++++
+ kernel/nvidia/include/media/camera_common.h   |   4 +
+ .../nvidia/include/media/tegra-v4l2-camera.h  |   4 +
+ 3 files changed, 126 insertions(+)
+
+diff --git a/kernel/nvidia/drivers/media/platform/tegra/camera/tegracam_ctrls.c b/kernel/nvidia/drivers/media/platform/tegra/camera/tegracam_ctrls.c
+index c5cff21e0..082050a85 100644
+--- a/kernel/nvidia/drivers/media/platform/tegra/camera/tegracam_ctrls.c
++++ b/kernel/nvidia/drivers/media/platform/tegra/camera/tegracam_ctrls.c
+@@ -192,6 +192,48 @@ static struct v4l2_ctrl_config ctrl_cfg_list[] = {
+ 		.max = CTRL_U8_MAX,
+ 		.step = 1,
+ 	},
++	{
++		.ops = &tegracam_ctrl_ops,
++		.id = TEGRA_CAMERA_CID_TRIGGER_MODE,
++		.name = "Trigger Mode",
++		.type = V4L2_CTRL_TYPE_INTEGER,
++		.flags = 0,
++		.min = 0,
++		.max = 7,
++		.step = 1,
++	},
++	{
++		.ops = &tegracam_ctrl_ops,
++		.id = TEGRA_CAMERA_CID_IO_MODE,
++		.name = "IO Mode",
++		.type = V4L2_CTRL_TYPE_INTEGER,
++		.flags = 0,
++		.min = 0,
++		.max = 5,
++		.step = 1,
++	},
++	{
++		.ops = &tegracam_ctrl_ops,
++		.id = TEGRA_CAMERA_CID_BLACK_LEVEL,
++		.name = "Black Level",
++		.type = V4L2_CTRL_TYPE_INTEGER,
++		.flags = V4L2_CTRL_FLAG_SLIDER,
++		.min = CTRL_U32_MIN,
++		.max = CTRL_U32_MAX,
++		.def = CTRL_U32_MIN,
++		.step = 1,
++	},
++	{
++		.ops = &tegracam_ctrl_ops,
++		.id = TEGRA_CAMERA_CID_SINGLE_TRIGGER,
++		.name = "Single Trigger",
++		.type = V4L2_CTRL_TYPE_BUTTON,
++		.flags = 0,
++		.min = 0,
++		.max = 1,
++		.def = 0,
++		.step = 1,
++	},
+ };
+ 
+ static int tegracam_get_ctrl_index(u32 cid)
+@@ -333,6 +375,18 @@ static int tegracam_set_ctrls(struct tegracam_ctrl_handler *handler,
+ 
+ 	/* For controls that require sensor to be on */
+ 	switch (ctrl->id) {
++	case TEGRA_CAMERA_CID_TRIGGER_MODE:
++		err = ops->set_trigger_mode(tc_dev, *ctrl->p_new.p_s64);
++		break;
++	case TEGRA_CAMERA_CID_IO_MODE:
++		err = ops->set_io_mode(tc_dev, *ctrl->p_new.p_s64);
++		break;
++	case TEGRA_CAMERA_CID_BLACK_LEVEL:
++		err = ops->set_black_level(tc_dev, *ctrl->p_new.p_s64);
++		break;
++	case TEGRA_CAMERA_CID_SINGLE_TRIGGER:
++		err = ops->set_single_trigger(tc_dev, ctrl->val);
++		break;
+ 	case TEGRA_CAMERA_CID_GAIN:
+ 		if (*ctrl->p_new.p_s64 == ctrlprops->min_gain_val - 1)
+ 			return 0;
+@@ -743,6 +797,34 @@ static int tegracam_check_ctrl_ops(
+ 	/* Find missing sensor controls */
+ 	for (i = 0; i < ops->numctrls; i++) {
+ 		switch (cids[i]) {
++		case TEGRA_CAMERA_CID_TRIGGER_MODE:
++			if (ops->set_trigger_mode == NULL)
++				dev_err(dev,
++					"Missing TEGRA_CAMERA_CID_TRIGGER_MODE implementation\n");
++			if (ops->set_trigger_mode != NULL)
++				sensor_ops++;
++			break;
++		case TEGRA_CAMERA_CID_IO_MODE:
++			if (ops->set_io_mode == NULL)
++				dev_err(dev,
++					"Missing TEGRA_CAMERA_CID_IO_MODE implementation\n");
++			if (ops->set_io_mode != NULL)
++				sensor_ops++;
++			break;
++		case TEGRA_CAMERA_CID_BLACK_LEVEL:
++			if (ops->set_black_level == NULL)
++				dev_err(dev,
++					"Missing TEGRA_CAMERA_CID_BLACK_LEVEL implementation\n");
++			if (ops->set_black_level != NULL)
++				sensor_ops++;
++			break;
++		case TEGRA_CAMERA_CID_SINGLE_TRIGGER:
++			if (ops->set_single_trigger == NULL)
++				dev_err(dev,
++					"Missing TEGRA_CAMERA_CID_SINGLE_TRIGGER implementation\n");
++			if (ops->set_single_trigger != NULL)
++				sensor_ops++;
++			break;
+ 		case TEGRA_CAMERA_CID_GAIN:
+ 			if (ops->set_gain == NULL && ops->set_gain_ex == NULL)
+ 				dev_err(dev,
+@@ -919,6 +1001,42 @@ static int tegracam_check_ctrl_cids(struct tegracam_ctrl_handler *handler)
+ 	int errors_found = 0;
+ 
+ 	/* Find missing sensor control IDs */
++	if (ops->set_trigger_mode != NULL) {
++		if (!find_matching_cid(ops->ctrl_cid_list,
++			ops->numctrls,
++			TEGRA_CAMERA_CID_TRIGGER_MODE)) {
++			dev_err(dev, "Missing TEGRA_CAMERA_CID_TRIGGER_MODE registration\n");
++			errors_found++;
++		}
++	}
++
++	if (ops->set_io_mode != NULL) {
++		if (!find_matching_cid(ops->ctrl_cid_list,
++			ops->numctrls,
++			TEGRA_CAMERA_CID_IO_MODE)) {
++			dev_err(dev, "Missing TEGRA_CAMERA_CID_IO_MODE registration\n");
++			errors_found++;
++		}
++	}
++
++	if (ops->set_black_level != NULL) {
++		if (!find_matching_cid(ops->ctrl_cid_list,
++			ops->numctrls,
++			TEGRA_CAMERA_CID_BLACK_LEVEL)) {
++			dev_err(dev, "Missing TEGRA_CAMERA_CID_BLACK_LEVEL registration\n");
++			errors_found++;
++		}
++	}
++
++	if (ops->set_single_trigger != NULL) {
++		if (!find_matching_cid(ops->ctrl_cid_list,
++			ops->numctrls,
++			TEGRA_CAMERA_CID_SINGLE_TRIGGER)) {
++			dev_err(dev, "Missing TEGRA_CAMERA_CID_SINGLE_TRIGGER registration\n");
++			errors_found++;
++		}
++	}
++
+ 	if (ops->set_gain != NULL || ops->set_gain_ex != NULL) {
+ 		if (!find_matching_cid(ops->ctrl_cid_list,
+ 			ops->numctrls,
+diff --git a/kernel/nvidia/include/media/camera_common.h b/kernel/nvidia/include/media/camera_common.h
+index d4e00ad25..d0079e28d 100644
+--- a/kernel/nvidia/include/media/camera_common.h
++++ b/kernel/nvidia/include/media/camera_common.h
+@@ -195,6 +195,10 @@ struct tegracam_ctrl_ops {
+ 	u32 compound_ctrl_size[TEGRA_CAM_MAX_COMPOUND_CONTROLS];
+ 	const u32 *ctrl_cid_list;
+ 	bool is_blob_supported;
++	int (*set_trigger_mode)(struct tegracam_device *tc_dev, s64 val);
++	int (*set_io_mode)(struct tegracam_device *tc_dev, s64 val);
++	int (*set_black_level)(struct tegracam_device *tc_dev, s64 val);
++	int (*set_single_trigger)(struct tegracam_device *tc_dev, bool val);
+ 	int (*set_gain)(struct tegracam_device *tc_dev, s64 val);
+ 	int (*set_exposure)(struct tegracam_device *tc_dev, s64 val);
+ 	int (*set_exposure_short)(struct tegracam_device *tc_dev, s64 val);
+diff --git a/kernel/nvidia/include/media/tegra-v4l2-camera.h b/kernel/nvidia/include/media/tegra-v4l2-camera.h
+index 49aed5bb2..e0242dcfd 100644
+--- a/kernel/nvidia/include/media/tegra-v4l2-camera.h
++++ b/kernel/nvidia/include/media/tegra-v4l2-camera.h
+@@ -39,6 +39,10 @@
+ #define TEGRA_CAMERA_CID_EXPOSURE_SHORT		(TEGRA_CAMERA_CID_BASE+12)
+ #define TEGRA_CAMERA_CID_STEREO_EEPROM		(TEGRA_CAMERA_CID_BASE+13)
+ #define TEGRA_CAMERA_CID_ALTERNATING_EXPOSURE	(TEGRA_CAMERA_CID_BASE+14)
++#define TEGRA_CAMERA_CID_TRIGGER_MODE		(TEGRA_CAMERA_CID_BASE+15)
++#define TEGRA_CAMERA_CID_IO_MODE		(TEGRA_CAMERA_CID_BASE+16)
++#define TEGRA_CAMERA_CID_BLACK_LEVEL		(TEGRA_CAMERA_CID_BASE+17)
++#define TEGRA_CAMERA_CID_SINGLE_TRIGGER		(TEGRA_CAMERA_CID_BASE+18)
+ 
+ #define TEGRA_CAMERA_CID_SENSOR_CONFIG		(TEGRA_CAMERA_CID_BASE+50)
+ #define TEGRA_CAMERA_CID_SENSOR_MODE_BLOB	(TEGRA_CAMERA_CID_BASE+51)
+-- 
+2.25.1
+

--- a/patch/kernel_Xavier_35.5.0+/0001-Increased-tegra-channel-timeout.patch
+++ b/patch/kernel_Xavier_35.5.0+/0001-Increased-tegra-channel-timeout.patch
@@ -1,0 +1,25 @@
+From efb04f50ce7e30187f3252f3ef425f6c59b2f4e6 Mon Sep 17 00:00:00 2001
+From: "/setup.sh" <support@vision-components.com>
+Date: Tue, 25 Apr 2023 15:13:20 +0200
+Subject: [PATCH] Increased tegra channel timeout.
+
+---
+ kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_fops.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_fops.c b/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+index b21b569..7c67a78 100644
+--- a/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_fops.c
++++ b/kernel/nvidia/drivers/media/platform/tegra/camera/vi/vi5_fops.c
+@@ -39,7 +39,7 @@
+ #define VI_CHANNEL_DEV "/dev/capture-vi-channel"
+ #define VI_CHAN_PATH_MAX 40
+ 
+-#define CAPTURE_TIMEOUT_MS	2500
++#define CAPTURE_TIMEOUT_MS	5000
+ 
+ static const struct vi_capture_setup default_setup = {
+ 	.channel_flags = 0
+-- 
+2.25.1
+

--- a/patch/kernel_Xavier_35.5.0+/0003-Changed-Interrupt-Mask-for-csi4-to-emit-CRC-and-mul.patch
+++ b/patch/kernel_Xavier_35.5.0+/0003-Changed-Interrupt-Mask-for-csi4-to-emit-CRC-and-mul.patch
@@ -1,0 +1,28 @@
+From 004b2535412a3184b74e1ee92a21c300ce7ad5b0 Mon Sep 17 00:00:00 2001
+From: Peter Martienssen <peter.martienssen@liquify-consulting.de>
+Date: Tue, 28 Sep 2021 15:04:11 +0200
+Subject: [PATCH 3/4] Changed Interrupt Mask for csi4 to emit CRC and
+ multi-bit errors.
+
+---
+ .../drivers/media/platform/tegra/camera/csi/csi4_fops.c       | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/kernel/nvidia/drivers/media/platform/tegra/camera/csi/csi4_fops.c b/kernel/nvidia/drivers/media/platform/tegra/camera/csi/csi4_fops.c
+index 66557f127..b9e5e2ead 100644
+--- a/kernel/nvidia/drivers/media/platform/tegra/camera/csi/csi4_fops.c
++++ b/kernel/nvidia/drivers/media/platform/tegra/camera/csi/csi4_fops.c
+@@ -91,6 +91,10 @@ static void csi4_stream_init(struct tegra_csi_channel *chan, int csi_port)
+ 	csi4_stream_write(chan, csi_port, ERROR_STATUS2VI_MASK, 0x0);
+ 	csi4_stream_write(chan, csi_port, INTR_MASK, 0x0);
+ 	csi4_stream_write(chan, csi_port, ERR_INTR_MASK, 0x0);
++	csi4_stream_write(chan, csi_port, INTR_MASK, PH_ECC_MULTI_BIT_ERR | PD_CRC_ERR_VC0 | PH_ECC_SINGLE_BIT_ERR_VC0);
++	csi4_stream_write(chan, csi_port, ERR_INTR_MASK, PH_ECC_MULTI_BIT_ERR | PD_CRC_ERR_VC0 | PH_ECC_SINGLE_BIT_ERR_VC0);
++	csi4_stream_write(chan, csi_port, ERROR_STATUS2VI_MASK, CFG_ERR_STATUS2VI_MASK_VC0 | CFG_ERR_STATUS2VI_MASK_VC1 |
++				CFG_ERR_STATUS2VI_MASK_VC2 | CFG_ERR_STATUS2VI_MASK_VC3);
+ }
+ 
+ static void csi4_stream_config(struct tegra_csi_channel *chan, int port_idx)
+-- 
+2.25.1
+


### PR DESCRIPTION
start fixing #81

- omitted the patch to apply to disable VB2_BUF_STATE_REQUEUEING as it didn't apply anymore (not sure if that is needed with kernel 5.10, Nvidia seems to have refactored that part of the code)

