### PR TITLE
fix: add prototypes and static declarations

### DIFF
--- a/src/driver/vc_mipi_camera.c
+++ b/src/driver/vc_mipi_camera.c
@@ -25,7 +25,7 @@ static struct sensor_mode_properties *tegracam_to_mode(struct tegracam_device *t
         return NULL;
 }
 
-struct tegra_channel *get_tegra_channel(struct tegracam_device *tc_dev)
+static struct tegra_channel *get_tegra_channel(struct tegracam_device *tc_dev)
 {
         struct vc_cam *cam = tegracam_to_cam(tc_dev);
         struct device *dev = vc_core_get_sen_device(cam);
@@ -84,7 +84,7 @@ struct tegra_channel *get_tegra_channel(struct tegracam_device *tc_dev)
         return video_get_drvdata(vdev_vi);
 }
 
-void vc_update_image_size_from_mode(struct tegracam_device *tc_dev,  __u32 *left, __u32 *top, __u32 *width, __u32 *height)
+static void vc_update_image_size_from_mode(struct tegracam_device *tc_dev,  __u32 *left, __u32 *top, __u32 *width, __u32 *height)
 {
         struct vc_cam *cam = tegracam_to_cam(tc_dev);
         struct vc_ctrl *ctrl = NULL;
@@ -244,7 +244,7 @@ __u32 g_tegra_width = 0;
 __u32 g_tegra_height = 0;
 __u32 g_tegra_line_length = 0;
 
-void vc_overwrite_image_size(struct tegracam_device *tc_dev, __u32 *width, __u32 *height, 
+static void vc_overwrite_image_size(struct tegracam_device *tc_dev, __u32 *width, __u32 *height, 
         __u32 *tegra_width, __u32 *tegra_height, __u32 *tegra_line_length)
 {
         if (g_width != 0) {
@@ -264,7 +264,7 @@ void vc_overwrite_image_size(struct tegracam_device *tc_dev, __u32 *width, __u32
         }
 }
 
-void vc_update_tegra_image_size(struct tegracam_device *tc_dev, __u32 width, __u32 height, __u32 line_length)
+static void vc_update_tegra_image_size(struct tegracam_device *tc_dev, __u32 width, __u32 height, __u32 line_length)
 {
         struct camera_common_frmfmt *frmfmt1 = (struct camera_common_frmfmt *)tc_dev->sensor_ops->frmfmt_table;
         struct camera_common_frmfmt *frmfmt2 = (struct camera_common_frmfmt *)tc_dev->s_data->frmfmt;
@@ -285,7 +285,7 @@ void vc_update_tegra_image_size(struct tegracam_device *tc_dev, __u32 width, __u
         }
 }
 
-void vc_update_tegra_controls(struct tegracam_device *tc_dev) 
+static void vc_update_tegra_controls(struct tegracam_device *tc_dev) 
 {
         struct vc_cam *cam = tegracam_to_cam(tc_dev);
         struct sensor_mode_properties *mode = tegracam_to_mode(tc_dev, 0);
@@ -579,7 +579,7 @@ static struct camera_common_sensor_ops vc_sensor_ops = {
         .parse_dt = vc_parse_dt,
 };
 
-int vc_init_frmfmt(struct device *dev, struct vc_cam *cam)
+static int vc_init_frmfmt(struct device *dev, struct vc_cam *cam)
 {
         struct camera_common_frmfmt *frmfmt = NULL;
         int *fps = NULL;
@@ -707,7 +707,7 @@ static void vc_init_binning(struct device *dev, struct vc_cam *cam)
         }
 }
 
-void vc_init_tegra_controls(struct tegracam_device *tc_dev) 
+static void vc_init_tegra_controls(struct tegracam_device *tc_dev)
 {
         struct vc_cam *cam = tegracam_to_cam(tc_dev);
         struct device *dev = tc_dev->dev;

--- a/src/driver/vc_mipi_core.c
+++ b/src/driver/vc_mipi_core.c
@@ -130,7 +130,7 @@ static int i2c_write_reg(struct device *dev, struct i2c_client *client, const __
         return ret == 1 ? 0 : -EIO;
 }
 
-int i2c_write_regs(struct i2c_client *client, const struct vc_reg *regs, const char* func)
+static int i2c_write_regs(struct i2c_client *client, const struct vc_reg *regs, const char* func)
 {
         int i;
 
@@ -637,7 +637,7 @@ __u32 vc_core_calculate_max_exposure(struct vc_cam *cam, __u8 num_lanes, __u8 fo
         }
 }
 
-__u32 vc_core_get_optimized_vmax(struct vc_cam *cam)
+static __u32 vc_core_get_optimized_vmax(struct vc_cam *cam)
 {
         struct vc_ctrl *ctrl = &cam->ctrl;
         struct vc_state *state = &cam->state;
@@ -681,7 +681,7 @@ __u32 vc_core_calculate_max_frame_rate(struct vc_cam *cam, __u8 num_lanes, __u8 
         return 1000000000 / (((__u64)period_1H_ns * vmax) / 1000);
 }
 
-vc_mode vc_core_get_mode(struct vc_cam *cam, __u8 num_lanes, __u8 format, __u8 binning)
+static vc_mode vc_core_get_mode(struct vc_cam *cam, __u8 num_lanes, __u8 format, __u8 binning)
 {
         struct device *dev = vc_core_get_sen_device(cam);
         struct vc_ctrl *ctrl = &cam->ctrl;
@@ -813,7 +813,7 @@ struct i2c_client *vc_mod_get_client(struct device *dev, struct i2c_adapter *ada
 }
 EXPORT_SYMBOL(vc_mod_get_client);
 
-int vc_mod_set_power(struct vc_cam *cam, int on)
+static int vc_mod_set_power(struct vc_cam *cam, int on)
 {
         struct vc_ctrl *ctrl = &cam->ctrl;
         struct i2c_client *client_mod = ctrl->client_mod;
@@ -1391,7 +1391,7 @@ static int vc_sen_read_image_size(struct vc_ctrl *ctrl, struct vc_frame *size)
         return 0;
 }
 
-struct vc_binning *vc_core_get_binning(struct vc_cam *cam)
+static struct vc_binning *vc_core_get_binning(struct vc_cam *cam)
 {
         struct vc_ctrl *ctrl = &cam->ctrl;
         struct vc_state *state = &cam->state;

--- a/src/driver/vc_mipi_core.h
+++ b/src/driver/vc_mipi_core.h
@@ -262,6 +262,8 @@ int write_binning_mode_regs(struct vc_cam *cam, __u8 num_lanes, __u8 format, __u
 vc_control vc_core_get_vmax(struct vc_cam *cam, __u8 num_lanes, __u8 format, __u8 binning);
 vc_control vc_core_get_blacklevel(struct vc_cam *cam, __u8 num_lanes, __u8 format, __u8 binning);
 __u32 vc_core_get_retrigger(struct vc_cam *cam, __u8 num_lanes, __u8 format, __u8 binning);
+void vc_core_limit_frame_size(struct vc_cam *cam, __u32 width, __u32 height);
+void vc_core_limit_frame_position(struct vc_cam *cam, __u32 left, __u32 top);
 
 // --- Function to initialize the vc core --------------------------------------
 int vc_core_init(struct vc_cam *cam, struct i2c_client *client);
@@ -282,6 +284,7 @@ int vc_mod_get_io_mode(struct vc_cam *cam);
 int vc_sen_set_roi(struct vc_cam *cam);
 int vc_sen_set_exposure(struct vc_cam *cam, int exposure);
 int vc_sen_set_gain(struct vc_cam *cam, int gain);
+int vc_sen_write_mode(struct vc_ctrl *ctrl, int mode);
 
 int vc_sen_set_blacklevel(struct vc_cam *cam, __u32 blacklevel);
 


### PR DESCRIPTION
I added this patch to my build using L4T 36.3 (related #97) to avoid `-Werror=missing-prototypes`  errors.