### PR TITLE
Avoid unsafe to_camera_common_data() dereference

### DIFF
--- a/patch/kernel_Xavier_36.4.0+/0001-Added-implementation-to-set-image-position-and-size-.patch
+++ b/patch/kernel_Xavier_36.4.0+/0001-Added-implementation-to-set-image-position-and-size-.patch
@@ -25,7 +25,7 @@ index 6f98c64..9bb0b7e 100644
 +	struct sensor_properties *sensor = &s_data->sensor_props;
 +	int mode_idx = 0;
 +
-+	if (sensor->sensor_modes != NULL && sensor->num_modes > 0 && mode_idx < sensor->num_modes) {
++	if (s_data != NULL && sensor->sensor_modes != NULL && sensor->num_modes > 0 && mode_idx < sensor->num_modes) {
 +		struct sensor_mode_properties *mode = &sensor->sensor_modes[mode_idx];
 +		struct sensor_image_properties *image = &mode->image_properties;
 +		image->left = left;
@@ -47,7 +47,7 @@ index 6f98c64..9bb0b7e 100644
 +
 +	pix->width = (pix->width / 32) * 32;
 +	pix->height = (pix->height / 4) * 4;
-+
++	if (s_data == NULL) return -EINVAL;
 +	s_data->def_width = pix->width;
 +	s_data->def_height = pix->height;
 +	if (s_data->frmfmt != NULL && s_data->numfmts > 0 && mode_idx < s_data->numfmts) {
@@ -96,7 +96,7 @@ index 6f98c64..9bb0b7e 100644
 +
 +	switch (selection->target) {
 +	case V4L2_SEL_TGT_CROP:
-+		if (sensor->sensor_modes != NULL && sensor->num_modes > 0 && mode_idx < sensor->num_modes) {
++		if (s_data != NULL && sensor->sensor_modes != NULL && sensor->num_modes > 0 && mode_idx < sensor->num_modes) {
 +			struct sensor_mode_properties *mode = &sensor->sensor_modes[mode_idx];
 +			struct sensor_image_properties *image = &mode->image_properties;
 +			selection->r.left = image->left;

--- a/patch/kernel_Xavier_36.4.0+/0001-Handler-function-ready_to_stream-introduced.patch
+++ b/patch/kernel_Xavier_36.4.0+/0001-Handler-function-ready_to_stream-introduced.patch
@@ -130,8 +130,8 @@ index fc8d9ac..e3d08a1 100644
 +
 +	int ret = 0;
 +
-+	dev_dbg(chan->vi->dev, "%s: s_data->mode=%d, s_data->mode_prop_idx=%d, s_data->sensor_mode_id=%d \n", __func__,
-+		s_data->mode, s_data->mode_prop_idx, s_data->sensor_mode_id);
++	if (s_data != NULL) { dev_dbg(chan->vi->dev, "%s: s_data->mode=%d, s_data->mode_prop_idx=%d, s_data->sensor_mode_id=%d \n", __func__,
++		s_data->mode, s_data->mode_prop_idx, s_data->sensor_mode_id); }
 +
 +	if (NULL == vi->fops) {
 +		dev_err(chan->vi->dev, "%s: Could not get fops! \n", __func__);


### PR DESCRIPTION
to_camera_common_data() actually parses the DT again and will return NULL if no sensor modes are defined. In this case it is unsafe to dereference the return value without previously checking for NULL.

I have a HDMI-CSI bridge chip used in parallel that doesn't define any sensor modes (since its only figured out at runtime), and the VC-MIPI changes were causing crashes. Sorry I didn't have a good setup to modify the patches properly, so it's inline.